### PR TITLE
add: Socket.IOによるAPIのクライアントを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.2",
     "socket.io": "^4.7.4",
+    "socket.io-client": "^4.7.4",
     "tailwindcss": "^3.4.1",
     "tailwindcss-safe-area": "github:mgn901/tailwindcss-safe-area"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   socket.io:
     specifier: ^4.7.4
     version: 4.7.4
+  socket.io-client:
+    specifier: ^4.7.4
+    version: 4.7.4
   tailwindcss:
     specifier: ^3.4.1
     version: 3.4.1
@@ -2469,6 +2472,20 @@ packages:
     dependencies:
       once: 1.4.0
     dev: true
+
+  /engine.io-client@6.5.3:
+    resolution: {integrity: sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-parser: 5.2.2
+      ws: 8.11.0
+      xmlhttprequest-ssl: 2.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
 
   /engine.io-parser@5.2.2:
     resolution: {integrity: sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==}
@@ -5114,6 +5131,20 @@ packages:
       - utf-8-validate
     dev: false
 
+  /socket.io-client@4.7.4:
+    resolution: {integrity: sha512-wh+OkeF0rAVCrABWQBaEjLfb7DVPotMbu0cgWgyR0v6eA4EoVnAwcIeIbcdTE3GT/H3kbdLl7OoH2+asoDRIIg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.1.0
+      debug: 4.3.4
+      engine.io-client: 6.5.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
@@ -5656,6 +5687,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
+
+  /xmlhttprequest-ssl@2.0.0:
+    resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
+    engines: {node: '>=0.4.0'}
     dev: false
 
   /y18n@5.0.8:

--- a/src/client/client-socket-io/ClientBase.ts
+++ b/src/client/client-socket-io/ClientBase.ts
@@ -1,0 +1,43 @@
+import { type IServerToClientEventParams } from '../../server/controller-socket-io/socketIoTypes.ts';
+import { type IDtoOfErrorOrException } from '../../server/controller/dto.ts';
+import { type TSocket } from './index.ts';
+
+export abstract class ClientBase extends EventTarget {
+  protected readonly socket: TSocket;
+
+  protected _error: IDtoOfErrorOrException | undefined;
+  public get error() {
+    return this._error;
+  }
+
+  protected _isProcessing = false;
+  public get isProcessing() {
+    return this._isProcessing;
+  }
+
+  public constructor(param: { socket: TSocket }) {
+    super();
+    this.socket = param.socket;
+  }
+
+  protected startProcess() {
+    this._isProcessing = true;
+    this.dispatchEvent(new Event('update'));
+  }
+
+  protected finishProcess(canceledErrorName: keyof IServerToClientEventParams & `${string}:error`) {
+    this.socket.removeAllListeners(canceledErrorName);
+    this._isProcessing = false;
+    this.dispatchEvent(new Event('update'));
+  }
+
+  protected handleError(
+    canceledEventName: keyof IServerToClientEventParams & `${string}:ok`,
+    param: IDtoOfErrorOrException,
+  ) {
+    this._error = param;
+    this._isProcessing = false;
+    this.dispatchEvent(new Event('error'));
+    this.socket.removeAllListeners(canceledEventName);
+  }
+}

--- a/src/client/client-socket-io/GameClient.ts
+++ b/src/client/client-socket-io/GameClient.ts
@@ -1,0 +1,59 @@
+import { type IClientToServerEventParams } from '../../server/controller-socket-io/socketIoTypes.ts';
+import { type IGameDto } from '../../server/controller/dto.ts';
+import { ClientBase } from './ClientBase.ts';
+
+export class GameClient extends ClientBase {
+  private _game: IGameDto | undefined;
+  public get game() {
+    return this._game;
+  }
+
+  public constructor(param: ConstructorParameters<typeof ClientBase>[0]) {
+    super(param);
+    this.socket.on('s:game:changed', (param) => {
+      this._game = param.game;
+    });
+  }
+
+  public create(param: IClientToServerEventParams['c:game:create']) {
+    this.socket.emit('c:game:create', param);
+    this.startProcess();
+
+    this.socket.once('s:game:create:ok', (param) => {
+      this._game = param.game;
+      this.finishProcess('s:game:create:error');
+    });
+
+    this.socket.once('s:game:create:error', (param) => {
+      this.handleError('s:game:create:ok', param);
+    });
+  }
+
+  public changeTurn(param: IClientToServerEventParams['c:game:changeTurn']) {
+    this.socket.emit('c:game:changeTurn', param);
+    this.startProcess();
+
+    this.socket.once('s:game:changeTurn:ok', (param) => {
+      this._game = param.game;
+      this.finishProcess('s:game:changeTurn:error');
+    });
+
+    this.socket.once('s:game:changeTurn:error', (param) => {
+      this.handleError('s:game:changeTurn:ok', param);
+    });
+  }
+
+  public win(param: IClientToServerEventParams['c:game:win']) {
+    this.socket.emit('c:game:win', param);
+    this.startProcess();
+
+    this.socket.once('s:game:win:ok', (param) => {
+      this._game = param.game;
+      this.finishProcess('s:game:win:error');
+    });
+
+    this.socket.once('s:game:win:error', (param) => {
+      this.handleError('s:game:win:ok', param);
+    });
+  }
+}

--- a/src/client/client-socket-io/HandTelepresenceClient.ts
+++ b/src/client/client-socket-io/HandTelepresenceClient.ts
@@ -1,0 +1,114 @@
+import { type IClientToServerEventParams } from '../../server/controller-socket-io/socketIoTypes.ts';
+import {
+  type IHandTelepresenceDto,
+  type IHandTelepresenceWithAuthenticationTokenDto,
+} from '../../server/controller/dto.ts';
+import { ClientBase } from './ClientBase.ts';
+
+export class HandTelepresenceClient extends ClientBase {
+  private _myHandTelepresence: IHandTelepresenceWithAuthenticationTokenDto | undefined;
+  public get myHandTelepresence() {
+    return this._myHandTelepresence;
+  }
+
+  private _handTelepresences = new Map<IHandTelepresenceDto['id'], IHandTelepresenceDto>();
+  public get handTelepresences() {
+    return this._handTelepresences;
+  }
+
+  public constructor(param: ConstructorParameters<typeof ClientBase>[0]) {
+    super(param);
+    this.socket.on('s:handTelepresence:ready', (param) => {
+      this._myHandTelepresence = param.handTelepresence;
+    });
+    this.socket.on('s:handTelepresence:changed', (param) => {
+      this._handTelepresences.set(param.handTelepresence.id, param.handTelepresence);
+    });
+  }
+
+  public create(param: IClientToServerEventParams['c:handTelepresence:create']) {
+    this.socket.emit('c:handTelepresence:create', param);
+    this.startProcess();
+
+    this.socket.once('s:handTelepresence:create:ok', (param) => {
+      this._myHandTelepresence = param.handTelepresence;
+      this.finishProcess('s:handTelepresence:create:error');
+    });
+
+    this.socket.once('s:game:create:error', (param) => {
+      this.handleError('s:handTelepresence:create:ok', param);
+    });
+  }
+
+  public holdCard(param: IClientToServerEventParams['c:handTelepresence:cards:hold']) {
+    this.socket.emit('c:handTelepresence:cards:hold', param);
+    this.startProcess();
+
+    this.socket.once('s:handTelepresence:cards:hold:ok', (param) => {
+      this._myHandTelepresence = {
+        ...param.handTelepresence,
+        authenticationToken: this._myHandTelepresence?.authenticationToken!,
+      };
+      this._handTelepresences.set(param.handTelepresence.id, param.handTelepresence);
+      this.finishProcess('s:handTelepresence:cards:hold:error');
+    });
+
+    this.socket.once('s:handTelepresence:cards:hold:error', (param) => {
+      this.handleError('s:handTelepresence:cards:hold:ok', param);
+    });
+  }
+
+  public lookCard(param: IClientToServerEventParams['c:handTelepresence:cards:look']) {
+    this.socket.emit('c:handTelepresence:cards:look', param);
+    this.startProcess();
+
+    this.socket.once('s:handTelepresence:cards:look:ok', (param) => {
+      this._myHandTelepresence = {
+        ...param.handTelepresence,
+        authenticationToken: this._myHandTelepresence?.authenticationToken!,
+      };
+      this._handTelepresences.set(param.handTelepresence.id, param.handTelepresence);
+      this.finishProcess('s:handTelepresence:cards:look:error');
+    });
+
+    this.socket.once('s:handTelepresence:cards:look:error', (param) => {
+      this.handleError('s:handTelepresence:cards:look:ok', param);
+    });
+  }
+
+  public scrubCard(param: IClientToServerEventParams['c:handTelepresence:cards:scrub']) {
+    this.socket.emit('c:handTelepresence:cards:scrub', param);
+    this.startProcess();
+
+    this.socket.once('s:handTelepresence:cards:scrub:ok', (param) => {
+      this._myHandTelepresence = {
+        ...param.handTelepresence,
+        authenticationToken: this._myHandTelepresence?.authenticationToken!,
+      };
+      this._handTelepresences.set(param.handTelepresence.id, param.handTelepresence);
+      this.finishProcess('s:handTelepresence:cards:scrub:error');
+    });
+
+    this.socket.once('s:handTelepresence:cards:scrub:error', (param) => {
+      this.handleError('s:handTelepresence:cards:scrub:ok', param);
+    });
+  }
+
+  public pickCard(param: IClientToServerEventParams['c:handTelepresence:cards:pick']) {
+    this.socket.emit('c:handTelepresence:cards:pick', param);
+    this.startProcess();
+
+    this.socket.once('s:handTelepresence:cards:pick:ok', (param) => {
+      this._myHandTelepresence = {
+        ...param.handTelepresence,
+        authenticationToken: this._myHandTelepresence?.authenticationToken!,
+      };
+      this._handTelepresences.set(param.handTelepresence.id, param.handTelepresence);
+      this.finishProcess('s:handTelepresence:cards:pick:error');
+    });
+
+    this.socket.once('s:handTelepresence:cards:pick:error', (param) => {
+      this.handleError('s:handTelepresence:cards:pick:ok', param);
+    });
+  }
+}

--- a/src/client/client-socket-io/PlayerClient.ts
+++ b/src/client/client-socket-io/PlayerClient.ts
@@ -1,0 +1,50 @@
+import { type IClientToServerEventParams } from '../../server/controller-socket-io/socketIoTypes.ts';
+import { type IPlayerDto } from '../../server/controller/dto.ts';
+import { ClientBase } from './ClientBase.ts';
+
+export class PlayerClient extends ClientBase {
+  private _players = new Map<IPlayerDto['id'], IPlayerDto>();
+  public get players() {
+    return this._players;
+  }
+
+  private _me: IPlayerDto | undefined;
+  public get me() {
+    return this._me;
+  }
+
+  public constructor(param: ConstructorParameters<typeof ClientBase>[0]) {
+    super(param);
+    this.socket.on('s:player:changed', (param) => {
+      this._players.set(param.player.id, param.player);
+    });
+  }
+
+  public proceedAction(param: IClientToServerEventParams['c:player:proceedAction']) {
+    this.socket.emit('c:player:proceedAction', param);
+    this.startProcess();
+
+    this.socket.once('s:player:proceedAction:ok', (param) => {
+      this._me = param.me;
+      this.finishProcess('s:player:proceedAction:error');
+    });
+
+    this.socket.once('s:player:proceedAction:error', (param) => {
+      this.handleError('s:player:proceedAction:ok', param);
+    });
+  }
+
+  public discard(param: IClientToServerEventParams['c:player:discard']) {
+    this.socket.emit('c:player:discard', param);
+    this.startProcess();
+
+    this.socket.once('s:player:discard:ok', (param) => {
+      this._me = param.player;
+      this.finishProcess('s:player:discard:error');
+    });
+
+    this.socket.once('s:player:discard:error', (param) => {
+      this.handleError('s:player:discard:ok', param);
+    });
+  }
+}

--- a/src/client/client-socket-io/WaitingRoomClient.ts
+++ b/src/client/client-socket-io/WaitingRoomClient.ts
@@ -1,0 +1,84 @@
+import { type IClientToServerEventParams } from '../../server/controller-socket-io/socketIoTypes.ts';
+import {
+  type IWaitingPlayerWithAuthenticationTokenDto,
+  type IWaitingRoomWithSecretDto,
+} from '../../server/controller/dto.ts';
+import { ClientBase } from './ClientBase.ts';
+
+export class WaitingRoomClient extends ClientBase {
+  private _waitingRoom: IWaitingRoomWithSecretDto | undefined;
+  public get waitingRoom() {
+    return this._waitingRoom;
+  }
+
+  private _me: IWaitingPlayerWithAuthenticationTokenDto | undefined;
+  public get me() {
+    return this._me;
+  }
+
+  public constructor(param: ConstructorParameters<typeof ClientBase>[0]) {
+    super(param);
+    this.socket.on('s:waitingRoom:changed', (param) => {
+      this._waitingRoom = { ...param.waitingRoom, secret: this.waitingRoom?.secret! };
+    });
+  }
+
+  public create() {
+    this.socket.emit('c:waitingRoom:create', {});
+    this.startProcess();
+
+    this.socket.once('s:waitingRoom:create:ok', (param) => {
+      this._waitingRoom = param.waitingRoom;
+      this._me = param.waitingPlayer;
+      this.finishProcess('s:waitingRoom:create:error');
+    });
+
+    this.socket.once('s:waitingRoom:create:error', (param) => {
+      this.handleError('s:waitingRoom:create:ok', param);
+    });
+  }
+
+  public join(param: IClientToServerEventParams['c:waitingRoom:players:join']) {
+    this.socket.emit('c:waitingRoom:players:join', param);
+    this.startProcess();
+
+    this.socket.once('s:waitingRoom:players:join:ok', (param) => {
+      this._waitingRoom = param.waitingRoom;
+      this._me = param.newPlayer;
+      this.finishProcess('s:waitingRoom:players:join:error');
+    });
+
+    this.socket.once('s:waitingRoom:players:join:error', (param) => {
+      this.handleError('s:waitingRoom:players:join:ok', param);
+    });
+  }
+
+  public kickPlayer(param: IClientToServerEventParams['c:waitingRoom:players:kick']) {
+    this.socket.emit('c:waitingRoom:players:kick', param);
+    this.startProcess();
+
+    this.socket.once('s:waitingRoom:players:kick:ok', (param) => {
+      this._waitingRoom = { ...param.waitingRoom, secret: this._waitingRoom?.secret! };
+      this.finishProcess('s:waitingRoom:players:kick:error');
+    });
+
+    this.socket.once('s:waitingRoom:players:kick:error', (param) => {
+      this.handleError('s:waitingRoom:players:kick:ok', param);
+    });
+  }
+
+  public leave(param: IClientToServerEventParams['c:waitingRoom:players:leave']) {
+    this.socket.emit('c:waitingRoom:players:leave', param);
+    this.startProcess();
+
+    this.socket.once('s:waitingRoom:players:leave:ok', (param) => {
+      this._waitingRoom = undefined;
+      this._me = undefined;
+      this.finishProcess('s:waitingRoom:players:leave:error');
+    });
+
+    this.socket.once('s:waitingRoom:players:leave:error', (param) => {
+      this.handleError('s:waitingRoom:players:leave:ok', param);
+    });
+  }
+}

--- a/src/client/client-socket-io/index.ts
+++ b/src/client/client-socket-io/index.ts
@@ -1,0 +1,19 @@
+import { type Socket, io } from 'socket.io-client';
+import {
+  type IClientToServerEvents,
+  type IServerToClientEvents,
+} from '../../server/controller-socket-io/socketIoTypes.ts';
+import { GameClient } from './GameClient.ts';
+import { HandTelepresenceClient } from './HandTelepresenceClient.ts';
+import { PlayerClient } from './PlayerClient.ts';
+import { WaitingRoomClient } from './WaitingRoomClient.ts';
+
+export type TSocket = Socket<IServerToClientEvents, IClientToServerEvents>;
+
+export class Client {
+  private readonly socket: TSocket = io();
+  public readonly waitingRoomClient = new WaitingRoomClient({ socket: this.socket });
+  public readonly gameClient = new GameClient({ socket: this.socket });
+  public readonly playerClient = new PlayerClient({ socket: this.socket });
+  public readonly handTelepresenceClient = new HandTelepresenceClient({ socket: this.socket });
+}

--- a/src/server/controller/dto.ts
+++ b/src/server/controller/dto.ts
@@ -126,3 +126,8 @@ export const toCardDto = (card: ICard): ICardDto => ({
   rank: card.rank,
   suit: card.suit,
 });
+
+export type IDtoOfErrorOrException = {
+  name: string;
+  message: string;
+};

--- a/src/server/controller/dto.ts
+++ b/src/server/controller/dto.ts
@@ -53,6 +53,9 @@ export type ICardDto = TDtoOf<ICard>;
 export const toGameDto = (game: Game): IGameDto => ({
   id: game.id,
   players: game.players.map(toPlayerDto),
+  winners: game.winners,
+  playerIdProceeding: game.playerIdProceeding,
+  playerIdProceeded: game.playerIdProceeded,
   table: toTableDto(game.table),
 });
 

--- a/src/server/interactors/games/changeTurn.ts
+++ b/src/server/interactors/games/changeTurn.ts
@@ -1,0 +1,62 @@
+import { type Game, type IllegalTurnChangeExeption } from '../../../model/game/Game.ts';
+import { type Player } from '../../../model/player/Player.ts';
+import {
+  type IllegalAuthenticationTokenException,
+  PlayerContext,
+} from '../../../model/player/PlayerContext.ts';
+import { type TLongSecret } from '../../../utils/random-values/TLongSecret.ts';
+import { Failure, Success, type TResult } from '../../../utils/result/TResult.ts';
+import { NotFoundException } from '../../errors/NotFoundException.ts';
+import { type IImplementationContainer } from '../../implementation-containers/IImplementationContainer.ts';
+import { type RepositoryError } from '../../repositories/RepositoryError.ts';
+
+export const changeTurn = (param: {
+  readonly gameId: Game['id'];
+  readonly playerId: Player['id'];
+  readonly authenticationToken: TLongSecret;
+  readonly implementationContainer: IImplementationContainer;
+}): TResult<
+  { game: Game },
+  | IllegalTurnChangeExeption
+  | IllegalAuthenticationTokenException
+  | NotFoundException
+  | RepositoryError
+> => {
+  const findGameResult = param.implementationContainer.gameRepository.findById(param.gameId);
+  if (findGameResult instanceof Failure) {
+    return findGameResult;
+  }
+  if (findGameResult.value === undefined) {
+    return new Failure(new NotFoundException('指定されたIDの競技は見つかりません。'));
+  }
+
+  const findPlayerResult = param.implementationContainer.playerRepository.findById(param.playerId);
+  if (findPlayerResult instanceof Failure) {
+    return findPlayerResult;
+  }
+  if (findPlayerResult.value === undefined) {
+    return new Failure(new NotFoundException('指定されたIDのプレイヤーは見つかりません。'));
+  }
+
+  const createContextResult = PlayerContext.create({
+    target: findPlayerResult.value,
+    authenticationToken: param.authenticationToken,
+  });
+  if (createContextResult instanceof Failure) {
+    return createContextResult;
+  }
+
+  const changeTurnResult = findGameResult.value.toTurnChanged({
+    context: createContextResult.value.context,
+  });
+  if (changeTurnResult instanceof Failure) {
+    return changeTurnResult;
+  }
+
+  const saveResult = param.implementationContainer.gameRepository.save(changeTurnResult.value.game);
+  if (saveResult instanceof Failure) {
+    return saveResult;
+  }
+
+  return new Success({ game: changeTurnResult.value.game });
+};

--- a/src/server/interactors/games/createWaitingRoom.ts
+++ b/src/server/interactors/games/createWaitingRoom.ts
@@ -1,3 +1,4 @@
+import { IWaitingPlayer } from '../../../model/game/IWaitingPlayer.ts';
 import { WaitingRoom } from '../../../model/game/WaitingRoom.ts';
 import { Failure, Success, type TResult } from '../../../utils/result/TResult.ts';
 import { type IImplementationContainer } from '../../implementation-containers/IImplementationContainer.ts';
@@ -5,7 +6,7 @@ import { type RepositoryError } from '../../repositories/RepositoryError.ts';
 
 export const createWaitingRoom = (param: {
   readonly implementationContainer: IImplementationContainer;
-}): TResult<{ waitingRoom: WaitingRoom }, RepositoryError> => {
+}): TResult<{ waitingRoom: WaitingRoom; waitingPlayer: IWaitingPlayer }, RepositoryError> => {
   const waitingRoom = WaitingRoom.create().value.waitingRoom;
 
   const saveResult = param.implementationContainer.waitingRoomRepository.save(waitingRoom);
@@ -13,5 +14,5 @@ export const createWaitingRoom = (param: {
     return saveResult;
   }
 
-  return new Success({ waitingRoom });
+  return new Success({ waitingRoom, waitingPlayer: waitingRoom.players[0] });
 };

--- a/src/server/interactors/games/win.ts
+++ b/src/server/interactors/games/win.ts
@@ -1,0 +1,68 @@
+import { type IllegalParamException } from '../../../model/errors/IllegalParamException.ts';
+import { type Game } from '../../../model/game/Game.ts';
+import { GamePlayerContext } from '../../../model/game/GamePlayerContext.ts';
+import { type Player } from '../../../model/player/Player.ts';
+import { type IllegalAuthenticationTokenException } from '../../../model/player/PlayerContext.ts';
+import { type TLongSecret } from '../../../utils/random-values/TLongSecret.ts';
+import { Failure, Success, type TResult } from '../../../utils/result/TResult.ts';
+import { NotFoundException } from '../../errors/NotFoundException.ts';
+import { type IImplementationContainer } from '../../implementation-containers/IImplementationContainer.ts';
+import { type RepositoryError } from '../../repositories/RepositoryError.ts';
+
+export const win = (param: {
+  readonly gameId: Game['id'];
+  readonly playerId: Player['id'];
+  readonly authenticationToken: TLongSecret;
+  readonly implementationContainer: IImplementationContainer;
+}): TResult<
+  { game: Game },
+  IllegalParamException | IllegalAuthenticationTokenException | NotFoundException | RepositoryError
+> => {
+  const findGameResult = param.implementationContainer.gameRepository.findById(param.gameId);
+  if (findGameResult instanceof Failure) {
+    return findGameResult;
+  }
+  if (findGameResult.value === undefined) {
+    return new Failure(new NotFoundException('指定されたIDの競技は見つかりません。'));
+  }
+
+  const findPlayerResult = param.implementationContainer.playerRepository.findById(param.playerId);
+  if (findPlayerResult instanceof Failure) {
+    return findPlayerResult;
+  }
+  if (findPlayerResult.value === undefined) {
+    return new Failure(new NotFoundException('指定されたIDのプレイヤーは見つかりません。'));
+  }
+
+  const createContextResult = GamePlayerContext.create({
+    target: findGameResult.value,
+    authenticationToken: param.authenticationToken,
+  });
+  if (createContextResult instanceof Failure) {
+    return createContextResult;
+  }
+
+  const winResult = findGameResult.value.toWinnerAdded({
+    context: createContextResult.value.context,
+    player: findPlayerResult.value,
+  });
+  if (winResult instanceof Failure) {
+    return winResult;
+  }
+
+  if (winResult.value.game.winners.length === winResult.value.game.players.length) {
+    const deleteResult = param.implementationContainer.gameRepository.delete(
+      winResult.value.game.id,
+    );
+    if (deleteResult instanceof Failure) {
+      return deleteResult;
+    }
+  } else {
+    const saveResult = param.implementationContainer.gameRepository.save(winResult.value.game);
+    if (saveResult instanceof Failure) {
+      return saveResult;
+    }
+  }
+
+  return new Success({ game: winResult.value.game });
+};

--- a/src/server/interactors/shared-hands/createHandTelepresence.ts
+++ b/src/server/interactors/shared-hands/createHandTelepresence.ts
@@ -13,7 +13,7 @@ export const createHandTelepresence = (param: {
   readonly cards: Pick<TParameterize<CardState>, 'card' | 'x' | 'y'>[];
   readonly implementationContainer: IImplementationContainer;
 }): TResult<
-  { handTelepresence: HandTelepresence },
+  { handTelepresence: HandTelepresence; playerIdOnPrev: Player['id'] },
   IllegalParamException | NotFoundException | RepositoryError
 > => {
   const findPlayerResult = param.implementationContainer.playerRepository.findById(param.playerId);
@@ -39,5 +39,8 @@ export const createHandTelepresence = (param: {
     cards,
   });
 
-  return new Success({ handTelepresence: createHandTelepresenceResult.value.sharedHand });
+  return new Success({
+    handTelepresence: createHandTelepresenceResult.value.sharedHand,
+    playerIdOnPrev: findPlayerResult.value.playerIdOnPrev,
+  });
 };


### PR DESCRIPTION
## その他の変更

- `Game`クラスで上がり、ターン進行を管理する。
- `HandTelepresence`作成時、`HandTelepresence`を作成する抜き取られる側のクライアントだけでなく、抜き取る側のクライアントにも`IHandTelepresenceWithAuthenticationTokenDto`を送るようにする。